### PR TITLE
added a link to spotify profile

### DIFF
--- a/client/src/components/FullEpisodes/FullEpisodeList.js
+++ b/client/src/components/FullEpisodes/FullEpisodeList.js
@@ -46,6 +46,9 @@ export const FullEpisodeList = () => {
                     ))}
                 </Row>
             </Container>
+            <div>
+                <h5 className="posts-title">For all full episodes click <Link to={"https://open.spotify.com/show/0vEOeYmVtFThauSn2NQVTW"}>here</Link></h5>
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
After thinking about it, if I'm only going to use 4 episodes at a time on the app, why not allow the user to go to the Spotify page where they can see more options and listen to whatever episode they want?